### PR TITLE
false is a parameter not a part of a method name

### DIFF
--- a/scripts/eastern_kingdoms/blackrock_spire/instance_blackrock_spire.cpp
+++ b/scripts/eastern_kingdoms/blackrock_spire/instance_blackrock_spire.cpp
@@ -460,7 +460,7 @@ void instance_blackrock_spire::JustDidDialogueStep(int32 iEntry)
             if (Creature* pRend = GetSingleCreatureFromStorage(NPC_REND_BLACKHAND))
             {
                 pRend->ForcedDespawn(5000);
-                pRend->SetWalkFALSE;
+                pRend->SetWalk(false);
                 pRend->GetMotionMaster()->MovePoint(0, aStadiumLocs[6].m_fX, aStadiumLocs[6].m_fY, aStadiumLocs[6].m_fZ);
             }
             m_uiStadiumEventTimer = 30000;


### PR DESCRIPTION
based on https://github.com/cmangos/mangos-classic/commit/e475d61d69aa383cb39a16bfd213592fb29742ef#src/game/Creature.h
