### PR TITLE
Fixed several GCC compile warnings

### DIFF
--- a/ScriptMgr.cpp
+++ b/ScriptMgr.cpp
@@ -35,7 +35,7 @@ void LoadDatabase()
     if (SD2Database.Initialize(strSD2DBinfo.c_str()))
     {
         outstring_log("SD2: ScriptDev2 database initialized.");
-        outstring_log("");
+        outstring_log(" ");
 
         pSystemMgr.LoadVersion();
         pSystemMgr.LoadScriptTexts();
@@ -79,7 +79,7 @@ MANGOS_DLL_EXPORT
 void InitScriptLibrary()
 {
     // ScriptDev2 startup
-    outstring_log("");
+    outstring_log(" ");
     outstring_log(" MMM  MMM    MM");
     outstring_log("M  MM M  M  M  M");
     outstring_log("MM    M   M   M");
@@ -87,7 +87,7 @@ void InitScriptLibrary()
     outstring_log("   MM M   M MMMM");
     outstring_log("MM  M M  M ");
     outstring_log(" MMM  MMM  http://www.scriptdev2.com");
-    outstring_log("");
+    outstring_log(" ");
 
     // Get configuration file
     bool configFailure = false;
@@ -107,7 +107,7 @@ void InitScriptLibrary()
     if (SD2Config.GetIntDefault("ConfVersion", 0) != SD2_CONF_VERSION)
         script_error_log("Configuration file version doesn't match expected version. Some config variables may be wrong or missing.");
 
-    outstring_log("");
+    outstring_log(" ");
 
     // Load database (must be called after SD2Config.SetSource).
     LoadDatabase();
@@ -115,7 +115,7 @@ void InitScriptLibrary()
     outstring_log("SD2: Loading C++ scripts");
     BarGoLink bar(1);
     bar.step();
-    outstring_log("");
+    outstring_log(" ");
 
     // Resize script ids to needed ammount of assigned ScriptNames (from core)
     m_scripts.resize(GetScriptIdsCount(), NULL);

--- a/base/escort_ai.cpp
+++ b/base/escort_ai.cpp
@@ -49,7 +49,7 @@ void npc_escortAI::GetAIInformation(ChatHandler& reader)
             oss << "\nNext Waypoint Id = " << CurrentWP->uiId << " Position: " << CurrentWP->fX << " " << CurrentWP->fY << " " << CurrentWP->fZ;
     }
 
-    reader.PSendSysMessage(oss.str().c_str());
+    reader.PSendSysMessage("%s", oss.str().c_str());
 }
 
 bool npc_escortAI::IsVisible(Unit* pWho) const

--- a/scripts/eastern_kingdoms/blackrock_spire/blackrock_spire.h
+++ b/scripts/eastern_kingdoms/blackrock_spire/blackrock_spire.h
@@ -74,12 +74,12 @@ struct SpawnLocation
 static const SpawnLocation aStadiumLocs[7] =
 {
     {210.00f, -420.30f, 110.94f, 3.14f},                    // dragons summon location
-    {210.14f, -397.54f, 111.1f},                            // Gyth summon location
-    {163.62f, -420.33f, 110.47f},                           // center of the stadium location (for movement)
+    {210.14f, -397.54f, 111.1f,   NULL},                    // Gyth summon location
+    {163.62f, -420.33f, 110.47f,  NULL},                    // center of the stadium location (for movement)
     {164.63f, -444.04f, 121.97f, 3.22f},                    // Lord Nefarius summon position
     {161.01f, -443.73f, 121.97f, 6.26f},                    // Rend summon position
     {164.64f, -443.30f, 121.97f, 1.61f},                    // Nefarius move position
-    {165.74f, -466.46f, 116.80f},                           // Rend move position
+    {165.74f, -466.46f, 116.80f,  NULL}                     // Rend move position
 };
 
 // Stadium event description

--- a/scripts/eastern_kingdoms/blackrock_spire/instance_blackrock_spire.cpp
+++ b/scripts/eastern_kingdoms/blackrock_spire/instance_blackrock_spire.cpp
@@ -568,8 +568,8 @@ void instance_blackrock_spire::DoSendNextFlamewreathWave()
             float fX, fY, fZ;
             pSummoner->GetRandomPoint(rookeryEventSpawnPos[0], rookeryEventSpawnPos[1], rookeryEventSpawnPos[2], 2.5f, fX, fY, fZ);
             // Summon Rookery Hatchers in first wave, else random
-            if (pSummoned = pSummoner->SummonCreature(urand(0, 1) && m_uiFlamewreathWaveCount ? NPC_ROOKERY_GUARDIAN : NPC_ROOKERY_HATCHER,
-                            fX, fY, fZ, 0.0, TEMPSUMMON_TIMED_OOC_OR_DEAD_DESPAWN, 300000))
+            if ((pSummoned = pSummoner->SummonCreature(urand(0, 1) && m_uiFlamewreathWaveCount ? NPC_ROOKERY_GUARDIAN : NPC_ROOKERY_HATCHER,
+                            fX, fY, fZ, 0.0, TEMPSUMMON_TIMED_OOC_OR_DEAD_DESPAWN, 300000)))
             {
                 pSummoner->GetContactPoint(pSummoned, fX, fY, fZ);
                 pSummoned->GetMotionMaster()->MovePoint(1, fX, fY, pSummoner->GetPositionZ());

--- a/scripts/eastern_kingdoms/stratholme/stratholme.h
+++ b/scripts/eastern_kingdoms/stratholme/stratholme.h
@@ -88,20 +88,20 @@ struct EventLocation
 
 static const EventLocation aStratholmeLocation[] =
 {
-    {3725.577f, -3599.484f, 142.367f},                      // Barthilas door run
+    {3725.577f, -3599.484f, 142.367f,  NULL},               // Barthilas door run
     {4068.284f, -3535.678f, 122.771f, 2.50f},               // Barthilas tele
     {4032.643f, -3378.546f, 119.752f, 4.74f},               // Ramstein summon loc
-    {4032.843f, -3390.246f, 119.732f},                      // Ramstein move loc
+    {4032.843f, -3390.246f, 119.732f,  NULL},               // Ramstein move loc
     {3969.357f, -3391.871f, 119.116f, 5.91f},               // Skeletons summon loc
-    {4033.044f, -3431.031f, 119.055f},                      // Skeletons move loc
+    {4033.044f, -3431.031f, 119.055f,  NULL},               // Skeletons move loc
     {4032.602f, -3378.506f, 119.752f, 4.74f},               // Guards summon loc
-    {4042.575f, -3337.929f, 115.059f}                       // Ysida move loc
+    {4042.575f, -3337.929f, 115.059f,  NULL}                // Ysida move loc
 };
 
 static const EventLocation aTimmyLocation[] =
 {
     {3696.851f, -3152.736f, 127.661f, 4.024f},              // Timmy spawn loc
-    {3668.603f, -3183.314f, 126.215f}                       // Courtyard mobs sort point
+    {3668.603f, -3183.314f, 126.215f,   NULL}               // Courtyard mobs sort point
 };
 
 struct ZigguratStore

--- a/scripts/eastern_kingdoms/sunken_temple/sunken_temple.h
+++ b/scripts/eastern_kingdoms/sunken_temple/sunken_temple.h
@@ -98,8 +98,8 @@ static const SummonLocations aSunkenTempleLocation[] =
 // Summon location for the suppressors
 static const SummonLocations aHakkariDoorLocations[2] =
 {
-    { -420.629f, 276.682f, -90.827f},
-    { -512.015f, 276.134f, -90.827f}
+    { -420.629f, 276.682f, -90.827f, NULL},
+    { -512.015f, 276.134f, -90.827f, NULL}
 };
 
 class MANGOS_DLL_DECL instance_sunken_temple : public ScriptedInstance

--- a/scripts/kalimdor/moonglade.cpp
+++ b/scripts/kalimdor/moonglade.cpp
@@ -135,29 +135,29 @@ struct EventLocations
 static EventLocations aEranikusLocations[] =
 {
     {7881.72f, -2651.23f, 493.29f, 0.40f},          // eranikus spawn loc
-    {7929.86f, -2574.88f, 505.35f},                 // eranikus flight move loc
-    {7912.98f, -2568.99f, 488.71f},                 // eranikus combat move loc
-    {7906.57f, -2565.63f, 488.39f},                 // eranikus redeemed loc
+    {7929.86f, -2574.88f, 505.35f,  NULL},          // eranikus flight move loc
+    {7912.98f, -2568.99f, 488.71f,  NULL},          // eranikus combat move loc
+    {7906.57f, -2565.63f, 488.39f,  NULL}           // eranikus redeemed loc
 };
 
 static EventLocations aTyrandeLocations[] =
 {
     // Tyrande should appear along the pathway, but because of the missing pathfinding we'll summon here closer to Eranikus
     {7948.89f, -2575.58f, 490.05f, 3.03f},          // tyrande spawn loc
-    {7888.32f, -2566.25f, 487.02f},                 // tyrande heal loc
-    {7901.83f, -2565.24f, 488.04f},                 // tyrande eranikus loc
+    {7888.32f, -2566.25f, 487.02f,  NULL},          // tyrande heal loc
+    {7901.83f, -2565.24f, 488.04f,  NULL}           // tyrande eranikus loc
 };
 
 static EventLocations aShadowsLocations[] =
 {
     // Inside the house shades - first wave only
-    {7832.78f, -2604.57f, 489.29f},
-    {7826.68f, -2538.46f, 489.30f},
-    {7811.48f, -2573.20f, 488.49f},
+    {7832.78f, -2604.57f, 489.29f, NULL},
+    {7826.68f, -2538.46f, 489.30f, NULL},
+    {7811.48f, -2573.20f, 488.49f, NULL},
     // Outside shade points - basically only the first set of coords is used for the summoning; there is no solid proof of using the other coords
-    {7888.32f, -2566.25f, 487.02f},
-    {7946.12f, -2577.10f, 489.97f},
-    {7963.00f, -2492.03f, 487.84f}
+    {7888.32f, -2566.25f, 487.02f, NULL},
+    {7946.12f, -2577.10f, 489.97f, NULL},
+    {7963.00f, -2492.03f, 487.84f, NULL}
 };
 
 struct MANGOS_DLL_DECL npc_keeper_remulosAI : public npc_escortAI, private DialogueHelper

--- a/scripts/kalimdor/ruins_of_ahnqiraj/ruins_of_ahnqiraj.h
+++ b/scripts/kalimdor/ruins_of_ahnqiraj/ruins_of_ahnqiraj.h
@@ -72,11 +72,11 @@ static const SpawnLocation aAndorovSpawnLocs[MAX_HELPERS] =
 // Movement locations for Andorov
 static const SpawnLocation aAndorovMoveLocs[] =
 {
-    {0, -8701.51f, 1561.80f, 32.092f},
-    {0, -8718.66f, 1577.69f, 21.612f},
+    {0, -8701.51f, 1561.80f, 32.092f, NULL},
+    {0, -8718.66f, 1577.69f, 21.612f, NULL},
     {0, -8876.97f, 1651.96f, 21.57f, 5.52f},
-    {0, -8882.15f, 1602.77f, 21.386f},
-    {0, -8940.45f, 1550.69f, 21.616f},
+    {0, -8882.15f, 1602.77f, 21.386f, NULL},
+    {0, -8940.45f, 1550.69f, 21.616f, NULL}
 };
 
 struct SortingParameters

--- a/scripts/kalimdor/silithus.cpp
+++ b/scripts/kalimdor/silithus.cpp
@@ -199,17 +199,17 @@ static EventLocations aEternalBoardNPCs[MAX_DRAGONS] =
 
 static EventLocations aEternalBoardMovement[] =
 {
-    { -8159.951f, 1525.241f, 74.994f},          // 0 Flight position for dragons
-    { -8106.238f, 1525.948f, 2.639f},           // 1 Anachronos gate location
-    { -8103.861f, 1525.923f, 2.677f},           // 2 Fandral gate location
-    { -8107.387f, 1523.641f, 2.609f},           // 3 Shattered scepter
-    { -8100.921f, 1527.740f, 2.871f},           // 4 Fandral epilogue location
-    { -8115.270f, 1515.926f, 3.305f},           // 5 Anachronos gather broken scepter 1
-    { -8116.879f, 1530.615f, 3.762f},           // 6 Anachronos gather broken scepter 2
-    { -7997.790f, 1548.664f, 3.738f},           // 7 Fandral exit location
-    { -8061.933f, 1496.196f, 2.556f},           // 8 Anachronos launch location
-    { -8008.705f, 1446.063f, 44.104f},          // 9 Anachronos flight location
-    { -8085.748f, 1521.484f, 2.624f}            // 10 Anchor point for the army summoning
+    { -8159.951f, 1525.241f, 74.994f, NULL, NULL},          // 0 Flight position for dragons
+    { -8106.238f, 1525.948f, 2.639f,  NULL, NULL},          // 1 Anachronos gate location
+    { -8103.861f, 1525.923f, 2.677f,  NULL, NULL},          // 2 Fandral gate location
+    { -8107.387f, 1523.641f, 2.609f,  NULL, NULL},          // 3 Shattered scepter
+    { -8100.921f, 1527.740f, 2.871f,  NULL, NULL},          // 4 Fandral epilogue location
+    { -8115.270f, 1515.926f, 3.305f,  NULL, NULL},          // 5 Anachronos gather broken scepter 1
+    { -8116.879f, 1530.615f, 3.762f,  NULL, NULL},          // 6 Anachronos gather broken scepter 2
+    { -7997.790f, 1548.664f, 3.738f,  NULL, NULL},          // 7 Fandral exit location
+    { -8061.933f, 1496.196f, 2.556f,  NULL, NULL},          // 8 Anachronos launch location
+    { -8008.705f, 1446.063f, 44.104f, NULL, NULL},          // 9 Anachronos flight location
+    { -8085.748f, 1521.484f, 2.624f,  NULL, NULL}           // 10 Anchor point for the army summoning
 };
 
 struct MANGOS_DLL_DECL npc_anachronos_the_ancientAI : public ScriptedAI, private DialogueHelper

--- a/scripts/kalimdor/temple_of_ahnqiraj/boss_cthun.cpp
+++ b/scripts/kalimdor/temple_of_ahnqiraj/boss_cthun.cpp
@@ -289,6 +289,8 @@ struct MANGOS_DLL_DECL boss_eye_of_cthunAI : public Scripted_NoMovementAI
                     m_uiDarkGlareEndTimer -= uiDiff;
 
                 break;
+            default:
+                break;
         }
 
         if (m_uiClawTentacleTimer < uiDiff)
@@ -611,6 +613,8 @@ struct MANGOS_DLL_DECL boss_cthunAI : public Scripted_NoMovementAI
                 else
                     m_uiPhaseTimer -= uiDiff;
 
+                break;
+            default:
                 break;
         }
 

--- a/scripts/kalimdor/temple_of_ahnqiraj/mob_anubisath_sentinel.cpp
+++ b/scripts/kalimdor/temple_of_ahnqiraj/mob_anubisath_sentinel.cpp
@@ -68,7 +68,7 @@ struct MANGOS_DLL_DECL npc_anubisath_sentinelAI : public ScriptedAI
         if (m_lAssistList.size() == MAX_BUDDY)
             reader.PSendSysMessage("Anubisath Sentinel - proper group found");
         else
-            reader.PSendSysMessage("Anubisath Sentinel - not correct number of mobs for group found. Number found %u, should be %u", m_lAssistList.size(), MAX_BUDDY);
+            reader.PSendSysMessage("Anubisath Sentinel - not correct number of mobs for group found. Number found " SIZEFMTD ", should be %u", m_lAssistList.size(), MAX_BUDDY);
     }
 
     void JustReachedHome() override

--- a/scripts/kalimdor/winterspring.cpp
+++ b/scripts/kalimdor/winterspring.cpp
@@ -136,11 +136,11 @@ static EventLocations aWingThicketLocations[] =
     {5515.98f, -4903.43f, 846.30f, 4.58f},      // 0 right priestess summon loc
     {5501.94f, -4920.20f, 848.69f, 6.15f},      // 1 left priestess summon loc
     {5497.35f, -4906.49f, 850.83f, 2.76f},      // 2 guard of elune summon loc
-    {5518.38f, -4913.47f, 845.57f},             // 3 right priestess move loc
-    {5510.36f, -4921.17f, 846.33f},             // 4 left priestess move loc
-    {5511.31f, -4913.82f, 847.17f},             // 5 guard of elune move loc
-    {5518.51f, -4917.56f, 845.23f},             // 6 right priestess second move loc
-    {5514.40f, -4921.16f, 845.49f}              // 7 left priestess second move loc
+    {5518.38f, -4913.47f, 845.57f,  NULL},      // 3 right priestess move loc
+    {5510.36f, -4921.17f, 846.33f,  NULL},      // 4 left priestess move loc
+    {5511.31f, -4913.82f, 847.17f,  NULL},      // 5 guard of elune move loc
+    {5518.51f, -4917.56f, 845.23f,  NULL},      // 6 right priestess second move loc
+    {5514.40f, -4921.16f, 845.49f,  NULL}       // 7 left priestess second move loc
 };
 
 struct MANGOS_DLL_DECL npc_ranshallaAI : public npc_escortAI, private DialogueHelper

--- a/system/system.cpp
+++ b/system/system.cpp
@@ -45,7 +45,7 @@ void SystemMgr::LoadVersion()
     strSD2Version.append(_FULLVERSION);
 
     outstring_log("Loading %s", strSD2Version.c_str());
-    outstring_log("");
+    outstring_log(" ");
 }
 
 void SystemMgr::LoadScriptTexts()
@@ -122,14 +122,14 @@ void SystemMgr::LoadScriptWaypoints()
 
         delete pResult;
 
-        outstring_log("");
+        outstring_log(" ");
         outstring_log(">> Loaded %u Script Waypoint nodes.", uiNodeCount);
     }
     else
     {
         BarGoLink bar(1);
         bar.step();
-        outstring_log("");
+        outstring_log(" ");
         outstring_log(">> Loaded 0 Script Waypoints. DB table `script_waypoint` is empty.");
     }
 }

--- a/tool/git_id/git_id.cpp
+++ b/tool/git_id/git_id.cpp
@@ -146,8 +146,8 @@ bool find_path()
 
     // don't count the root
     int count_fwd = 0, count_back = 0;
-    for (ptr = cur_path - 1; ptr = strchr(ptr + 1, '/'); count_fwd++);
-    for (ptr = cur_path - 1; ptr = strchr(ptr + 1, '\\'); count_back++);
+    for (ptr = cur_path - 1; (ptr = strchr(ptr + 1, '/')); count_fwd++);
+    for (ptr = cur_path - 1; (ptr = strchr(ptr + 1, '\\')); count_back++);
     int count = std::max(count_fwd, count_back);
 
     char path[MAX_PATH];
@@ -431,7 +431,8 @@ bool get_sql_update_info(const char* buffer, sql_update_info& info)
     info.table[0] = '\0';
     int dummy[2];
     char dummyStr[MAX_BUF];
-    if (sscanf(buffer, SQL_REV_SCAN "_%[^_]_%d_%d", &dummy[0], &dummyStr, &dummy[1]) == 3)
+    
+    if (sscanf(buffer, SQL_REV_SCAN "_%[^_]_%d", &dummy[0], dummyStr, &dummy[1]) == 3)
         return false;
 
     if (sscanf(buffer, SQL_REV_SCAN "_%[^.].sql", &info.rev, info.db) != 2)


### PR DESCRIPTION
This commit takes care of pretty much all GCC compiler warnings. I've deliberately ignored all warnings about unused variables and parameters, because some of them might be needed in the future?
