### PR TITLE
Molten Core improve Garr & Golemagg Scripts

### DIFF
--- a/scripts/eastern_kingdoms/molten_core/boss_garr.cpp
+++ b/scripts/eastern_kingdoms/molten_core/boss_garr.cpp
@@ -16,8 +16,8 @@
 
 /* ScriptData
 SDName: Boss_Garr
-SD%Complete: 50
-SDComment: Garr's enrage is missing
+SD%Complete: 100
+SDComment: add explode only triggers > 10% hp
 SDCategory: Molten Core
 EndScriptData */
 
@@ -29,13 +29,12 @@ enum
     // Garr spells
     SPELL_ANTIMAGICPULSE        = 19492,
     SPELL_MAGMASHACKLES         = 19496,
-    SPELL_ENRAGE                = 19516,                    // TODO Stacking enrage (stacks to 10 times)
+    SPELL_ENRAGE                = 19516,
 
     // Add spells
     SPELL_ERUPTION              = 19497,
-    SPELL_MASSIVE_ERUPTION      = 20483,                    // TODO possible on death
     SPELL_IMMOLATE              = 20294,
-    SPELL_SEPARATION_ANXIETY    = 23492,                    // Used if separated too far from Garr, 21095 use unknown.
+    SPELL_SEPARATION_ANXIETY    = 23492,
 };
 
 struct MANGOS_DLL_DECL boss_garrAI : public ScriptedAI
@@ -158,6 +157,13 @@ struct MANGOS_DLL_DECL mob_fireswornAI : public ScriptedAI
         }
 
         DoMeleeAttackIfReady();
+    }
+
+    void JustDied(Unit* /*pKiller*/) override
+    {
+        Creature* pGarr = m_pInstance->GetSingleCreatureFromStorage(NPC_GARR);
+        if (pGarr && pGarr->isAlive())
+            pGarr->CastSpell(pGarr, SPELL_ENRAGE, true, NULL, NULL, pGarr->GetObjectGuid());
     }
 };
 

--- a/scripts/eastern_kingdoms/molten_core/boss_golemagg.cpp
+++ b/scripts/eastern_kingdoms/molten_core/boss_golemagg.cpp
@@ -16,8 +16,8 @@
 
 /* ScriptData
 SDName: Boss_Golemagg
-SD%Complete: 80
-SDComment: Rager need to be tied to boss (Despawn on boss-death)
+SD%Complete: 100
+SDComment:
 SDCategory: Molten Core
 EndScriptData */
 
@@ -58,12 +58,12 @@ struct MANGOS_DLL_DECL boss_golemaggAI : public ScriptedAI
         m_uiEarthquakeTimer = 3 * IN_MILLISECONDS;
         m_uiBuffTimer       = 1.5 * IN_MILLISECONDS;
         m_bEnraged = false;
-
-        m_creature->CastSpell(m_creature, SPELL_MAGMA_SPLASH, true);
     }
 
     void Aggro(Unit* /*pWho*/) override
     {
+        m_creature->CastSpell(m_creature, SPELL_MAGMA_SPLASH, true);
+
         if (m_pInstance)
             m_pInstance->SetData(TYPE_GOLEMAGG, IN_PROGRESS);
     }


### PR DESCRIPTION
Golemagg: 
Magma Splash was not working in my tests, but when its casted on combat start it does. 
Regarding the comment, i think the add despawning on boss death should be handled in DB?

Garr:
Add Enrage cast on Add death

Garr sacrified his adds randomly when he is > 20% health, but i could not find much information on this
